### PR TITLE
Add modern packaging support and refine .gitignore for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,19 +126,20 @@ cython_debug/
 *.com
 sqm*
 
-!example/01_LazyLigand/thiophenol.pdb
-!example/01_LazyLigand/*.py
-example/01_LazyLigand/*
+examples/01_LazyLigand/*
+!examples/01_LazyLigand/thiophenol.pdb
+!examples/01_LazyLigand/*.py
 
-!example/02_FreeLigand/thiophenol.pdb
-!example/02_FreeLigand/*.py
-example/02_FreeLigand/*
+examples/02_FreeLigand/*
+!examples/02_FreeLigand/thiophenol.pdb
+!examples/02_FreeLigand/*.py
 
-!example/03_ModifySteps/thiophenol.pdb
-!example/03_ModifySteps/*.py
-example/03_ModifySteps/*
+examples/03_ModifySteps/*
+!examples/03_ModifySteps/thiophenol.pdb
+!examples/03_ModifySteps/*.py
 
-!example/04_MultiResp/*.py
-!example/04_MultiResp/1Y27_lig.pdb
-!example/04_MultiResp/1Y27.pdb
-example/04_MultiResp/*
+examples/04_MultiResp/*
+!examples/04_MultiResp/*.py
+!examples/04_MultiResp/1Y27_lig.pdb
+!examples/04_MultiResp/1Y27.pdb
+

--- a/.gitignore
+++ b/.gitignore
@@ -127,18 +127,22 @@ cython_debug/
 sqm*
 
 examples/01_LazyLigand/*
+examples/01_LazyLigand/*.* 
 !examples/01_LazyLigand/thiophenol.pdb
 !examples/01_LazyLigand/*.py
 
 examples/02_FreeLigand/*
+examples/02_FreeLigand/*/*
 !examples/02_FreeLigand/thiophenol.pdb
 !examples/02_FreeLigand/*.py
 
 examples/03_ModifySteps/*
+examples/03_ModifySteps/*/*
 !examples/03_ModifySteps/thiophenol.pdb
 !examples/03_ModifySteps/*.py
 
 examples/04_MultiResp/*
+examples/04_MultiResp/*/*
 !examples/04_MultiResp/*.py
 !examples/04_MultiResp/1Y27_lig.pdb
 !examples/04_MultiResp/1Y27.pdb

--- a/.gitignore
+++ b/.gitignore
@@ -126,24 +126,23 @@ cython_debug/
 *.com
 sqm*
 
-./examples/01_LazyLigand/*
-./examples/01_LazyLigand/*/* 
-!./examples/01_LazyLigand/thiophenol.pdb
-!./examples/01_LazyLigand/*.py
-
+# Ignore everything in the directories
+/examples/01_LazyLigand/*
 /examples/02_FreeLigand/*
-/examples/02_FreeLigand/*/*
+/examples/03_ModifySteps/*
+/examples/04_MultiResp/*
+
+# Allow specific files
+!/examples/01_LazyLigand/thiophenol.pdb
+!/examples/01_LazyLigand/*.py
+
 !/examples/02_FreeLigand/thiophenol.pdb
 !/examples/02_FreeLigand/*.py
 
-/examples/03_ModifySteps/*
-/examples/03_ModifySteps/*/*
 !/examples/03_ModifySteps/thiophenol.pdb
 !/examples/03_ModifySteps/*.py
 
-./examples/04_MultiResp/*
-./examples/04_MultiResp/*/*
-!./examples/04_MultiResp/*.py
-!./examples/04_MultiResp/1Y27_lig.pdb
-!./examples/04_MultiResp/1Y27.pdb
+!/examples/04_MultiResp/*.py
+!/examples/04_MultiResp/1Y27_lig.pdb
+!/examples/04_MultiResp/1Y27.pdb
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ cython_debug/
 sqm*
 
 ./examples/01_LazyLigand/*
-./examples/01_LazyLigand/*.* 
+./examples/01_LazyLigand/*/* 
 !./examples/01_LazyLigand/thiophenol.pdb
 !./examples/01_LazyLigand/*.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -126,24 +126,24 @@ cython_debug/
 *.com
 sqm*
 
-examples/01_LazyLigand/*
-examples/01_LazyLigand/*.* 
-!examples/01_LazyLigand/thiophenol.pdb
-!examples/01_LazyLigand/*.py
+./examples/01_LazyLigand/*
+./examples/01_LazyLigand/*.* 
+!./examples/01_LazyLigand/thiophenol.pdb
+!./examples/01_LazyLigand/*.py
 
-examples/02_FreeLigand/*
-examples/02_FreeLigand/*/*
-!examples/02_FreeLigand/thiophenol.pdb
-!examples/02_FreeLigand/*.py
+/examples/02_FreeLigand/*
+/examples/02_FreeLigand/*/*
+!/examples/02_FreeLigand/thiophenol.pdb
+!/examples/02_FreeLigand/*.py
 
-examples/03_ModifySteps/*
-examples/03_ModifySteps/*/*
-!examples/03_ModifySteps/thiophenol.pdb
-!examples/03_ModifySteps/*.py
+/examples/03_ModifySteps/*
+/examples/03_ModifySteps/*/*
+!/examples/03_ModifySteps/thiophenol.pdb
+!/examples/03_ModifySteps/*.py
 
-examples/04_MultiResp/*
-examples/04_MultiResp/*/*
-!examples/04_MultiResp/*.py
-!examples/04_MultiResp/1Y27_lig.pdb
-!examples/04_MultiResp/1Y27.pdb
+./examples/04_MultiResp/*
+./examples/04_MultiResp/*/*
+!./examples/04_MultiResp/*.py
+!./examples/04_MultiResp/1Y27_lig.pdb
+!./examples/04_MultiResp/1Y27.pdb
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,20 @@ cython_debug/
 
 *.com
 sqm*
+
+!example/01_LazyLigand/thiophenol.pdb
+!example/01_LazyLigand/*.py
+example/01_LazyLigand/*
+
+!example/02_FreeLigand/thiophenol.pdb
+!example/02_FreeLigand/*.py
+example/02_FreeLigand/*
+
+!example/03_ModifySteps/thiophenol.pdb
+!example/03_ModifySteps/*.py
+example/03_ModifySteps/*
+
+!example/04_MultiResp/*.py
+!example/04_MultiResp/1Y27_lig.pdb
+!example/04_MultiResp/1Y27.pdb
+example/04_MultiResp/*

--- a/env.yaml
+++ b/env.yaml
@@ -1,0 +1,12 @@
+name: ligandparam
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::python>=3.10
+  - conda-forge::numpy<2
+  - conda-forge::parmed==4.0.0
+  - conda-forge::mdanalysis
+  - conda-forge::rdkit
+  - conda-forge::pandas
+  - pip 
+  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ dependencies = [
 urls = { "Homepage" = "https://github.com/piskulichz/ligandparam" }
 
 [tool.setuptools]
-packages = ["ligandparam"]
+packages = ["ligandparam", "ligandparam.io", "ligandparam.deprecated", "ligandparam.multiresp", "ligandparam.recipes", "ligandparam.stages"]
+include_package_data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,17 @@ dependencies = [
   "pandas",
   "requests",
   "MDAnalysis",
-  "pathlib"
+  "pathlib",
+  "parmed",
+  "rdkit"
 ]
 urls = { "Homepage" = "https://github.com/piskulichz/ligandparam" }
 
 [tool.setuptools]
-packages = ["ligandparam", "ligandparam.io", "ligandparam.deprecated", "ligandparam.multiresp", "ligandparam.recipes", "ligandparam.stages"]
-include_package_data = true
+packages = [
+      "ligandparam",
+      "ligandparam.io", 
+      "ligandparam.multiresp",
+      "ligandparam.recipes", 
+      "ligandparam.stages"
+  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ligandparam"
+version = "0.2.0"
+description = "A ligand parameterization package for Amber"
+readme = "README.md"
+requires-python = ">=3.6"
+license = {text = "MIT"}
+authors = [
+  {name = "Zeke Piskulich", email = "piskulichz@gmail.com"}
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent"
+]
+dependencies = [
+  "numpy<2",
+  "pandas",
+  "requests",
+  "MDAnalysis",
+  "pathlib"
+]
+urls = { "Homepage" = "https://github.com/piskulichz/ligandparam" }
+
+[tool.setuptools]
+packages = ["ligandparam"]

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name='ligandparam',
-    version='0.2.0',
-    author='Zeke Piskulich',
-    author_email='piskulichz@gmail.com',
-    description='A ligand parmameterization package for Amber',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/yourusername/my-python-package',
-    packages=find_packages(),
-    install_requires=open('requirements.txt').read().splitlines(),
-    classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-    ],
-    python_requires='>=3.6',
-)
+setup()


### PR DESCRIPTION
This pull request introduces a `pyproject.toml` for modern packaging, replacing the previous `setup.py` configuration. It updates the `pyproject.toml` to include additional dependencies such as 'parmed' and 'rdkit', and ensures package data inclusion. The `.gitignore` file is refined to streamline the exclusion of example files across various directories, while allowing specific files to be tracked. Additionally, a conda environment configuration is added for the ligandparam package, specifying necessary dependencies. This enhances the overall packaging and development experience for the project.