### PR TITLE
Add modern packaging with pyproject.toml and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,24 @@ cython_debug/
 
 *.com
 sqm*
+
+# Ignore everything in the directories
+/examples/01_LazyLigand/*
+/examples/02_FreeLigand/*
+/examples/03_ModifySteps/*
+/examples/04_MultiResp/*
+
+# Allow specific files
+!/examples/01_LazyLigand/thiophenol.pdb
+!/examples/01_LazyLigand/*.py
+
+!/examples/02_FreeLigand/thiophenol.pdb
+!/examples/02_FreeLigand/*.py
+
+!/examples/03_ModifySteps/thiophenol.pdb
+!/examples/03_ModifySteps/*.py
+
+!/examples/04_MultiResp/*.py
+!/examples/04_MultiResp/1Y27_lig.pdb
+!/examples/04_MultiResp/1Y27.pdb
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,3 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-   install:
-   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,3 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 numpydoc
+sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,1 @@
 numpydoc
-sphinx-ext-autodoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+numpydoc
+sphinx-ext-autodoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 numpydoc
 sphinx-rtd-theme
+MDAnalysis
+numpy<2
+parmed

--- a/docs/source/documentation_pages/examples.rst
+++ b/docs/source/documentation_pages/examples.rst
@@ -15,6 +15,7 @@ Currently, the following examples are available:
    ./examples/02_FreeLigand.rst
    ./examples/03_ModifySteps.rst
    ./examples/04_FromSmiles.rst
+   ./examples/05_CreatingNewRecipes.rst
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/documentation_pages/examples/01_LazyLigand.rst
+++ b/docs/source/documentation_pages/examples/01_LazyLigand.rst
@@ -23,7 +23,7 @@ all the recipes available in the module, whereas, importing a specific recipe wi
 
 .. code-block:: python
 
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
 
 The next step is to load the pdb file into the recipe of your choosing, and set various machine parameters. Full parameters that can be selected
@@ -99,7 +99,7 @@ Full code
     #!/usr/bin/env python
 
     # Import the module
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
     # Load the pdb as a instance of the LazyLigand class
     test = LazyLigand('thiophenol.pdb', netcharge=0, nproc=12, mem='60GB')

--- a/docs/source/documentation_pages/examples/02_FreeLigand.rst
+++ b/docs/source/documentation_pages/examples/02_FreeLigand.rst
@@ -27,7 +27,7 @@ all the recipes available in the module, whereas, importing a specific recipe wi
 
 .. code-block:: python
 
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
 
 The next step is to load the pdb file into the recipe of your choosing, and set various machine parameters. Full parameters that can be selected
@@ -110,7 +110,7 @@ Full code
     #!/usr/bin/env python
 
     # Import the module
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
     # Load the pdb as a instance of the FreeLigand class
     test = FreeLigand('thiophenol.pdb', netcharge=0,nproc=12,mem='60GB')

--- a/docs/source/documentation_pages/examples/03_ModifySteps.rst
+++ b/docs/source/documentation_pages/examples/03_ModifySteps.rst
@@ -27,7 +27,7 @@ to add the stages to the pipeline, and print them to the screen.
 .. code-block:: python
 
     # Import the module
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
     # Load the pdb as a instance of the FreeLigand class
     test = FreeLigand('thiophenol.pdb', netcharge=0,nproc=12,mem='60GB')
@@ -54,7 +54,7 @@ Stages can also be added to the pipeline, this requires two steps:
 
 .. code-block:: python
 
-    from ligandparam.stages.charge import StageNormalizeCharge
+    from ligandparam.stages import StageNormalizeCharge
 
     test.add_stage(StageNormalizeCharge("NormalizeA", orig_mol2=test.base_name+".resp.mol2",
                             new_mol2=test.base_name+".resp.mol2"))
@@ -89,7 +89,7 @@ Full code
     #!/usr/bin/env python
 
     # Import the module
-    from ligandparam.module import *
+    from ligandparam.recipes import *
 
     # Load the pdb as a instance of the FreeLigand class
     test = FreeLigand('thiophenol.pdb', netcharge=0,nproc=12,mem='60GB')
@@ -105,7 +105,7 @@ Full code
     test.remove_stage("Normalize1")
 
 
-    from ligandparam.stages.charge import StageNormalizeCharge
+    from ligandparam.stages import StageNormalizeCharge
 
     test.add_stage(StageNormalizeCharge("NormalizeA", base_cls=test, orig_mol2=test.base_name+".resp.mol2",
                             new_mol2=test.base_name+".resp.mol2"))

--- a/docs/source/documentation_pages/examples/05_CreatingNewRecipes.rst
+++ b/docs/source/documentation_pages/examples/05_CreatingNewRecipes.rst
@@ -7,11 +7,10 @@ Recipes are classes that combine the building blocks of the workflow for paramet
 
 However, you might find yourself wanting to generate new recipes that are tailored to your specific needs and/or workflow.
 
-In this example, we will demonstrate how to create a new recipe by subclassing the `Recipe` class and
- adding your own stages to the pipeline.
+In this example, we will demonstrate how to create a new recipe by subclassing the `Recipe` class and adding your own stages to the pipeline.
 
- Building from Scratch for One Time Use
- --------------------------------------
+Building from Scratch for One Time Use
+--------------------------------------
 
 If you are building a recipe for a one-time use, you can use the `Recipe` class directly and add the stages to the pipeline.
 
@@ -30,8 +29,7 @@ Here is an example of a simple recipe that only has two stages, `StageInitialize
                         new_mol2=new_recipe.base_name+".antechamber.mol2"))
     new_recipe.execute(dry_run=False)
 
-This script might be useful for generating a mol2 file from a pdb file, creating bcc charges,
- and then normalizing the charges to zero.
+This script might be useful for generating a mol2 file from a pdb file, creating bcc charges, and then normalizing the charges to zero.
 
 
 Building from Scratch for Reuse

--- a/docs/source/documentation_pages/examples/05_CreatingNewRecipes.rst
+++ b/docs/source/documentation_pages/examples/05_CreatingNewRecipes.rst
@@ -1,0 +1,67 @@
+Creating New Recipes
+=====================
+
+Recipes are classes that combine the building blocks of the workflow for parametrizing a ligand. 
+
+`LazyLigand`, `FreeLigand`, and `BuildLigand` are examples of recipes that are included in the ligandparam package by default.
+
+However, you might find yourself wanting to generate new recipes that are tailored to your specific needs and/or workflow.
+
+In this example, we will demonstrate how to create a new recipe by subclassing the `Recipe` class and
+ adding your own stages to the pipeline.
+
+ Building from Scratch for One Time Use
+ --------------------------------------
+
+If you are building a recipe for a one-time use, you can use the `Recipe` class directly and add the stages to the pipeline.
+
+Here is an example of a simple recipe that only has two stages, `StageInitialize` and `StageNormalizeCharge`:
+
+.. code-block:: python
+
+    from ligandparam.recipes import Recipe
+    from ligandparam.stages import *
+
+    new_recipe = Recipe('my_ligand.pdb', netcharge=0, nproc=12, mem='60GB')
+    new_recipe.add_stage(StageInitialize("Initialize", base_cls=new_recipe))
+    new_recipe.add_stage(StageNormalizeCharge("NormalizeCharge", 
+                        base_cls=new_recipe, 
+                        orig_mol2=new_recipe.base_name+".antechamber.mol2",
+                        new_mol2=new_recipe.base_name+".antechamber.mol2"))
+    new_recipe.execute(dry_run=False)
+
+This script might be useful for generating a mol2 file from a pdb file, creating bcc charges,
+ and then normalizing the charges to zero.
+
+
+Building from Scratch for Reuse
+-------------------------------
+
+If you are building a recipe that you plan to reuse, you should subclass the `Recipe` class and add the stages to the pipeline.
+
+Here is an example of a simple recipe that only has two stages like before, `StageInitialize` and `StageNormalizeCharge`:
+
+.. code-block:: python
+
+    from ligandparam.recipes import Recipe
+    from ligandparam.stages import *
+
+    class MyNewRecipe(Recipe):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            return
+        def setup(self):
+            self.stages = [
+                StageInitialize("Initialize", base_cls=self),
+                StageNormalizeCharge("Normalize1", base_cls=self, 
+                                    orig_mol2=self.base_name+".antechamber.mol2", 
+                                    new_mol2=self.base_name+".antechamber.mol2")
+            ]
+
+Then you can use this recipe just like before.:
+
+.. code-block:: python
+
+    new_recipe = MyNewRecipe('my_ligand.pdb', netcharge=0, nproc=12, mem='60GB')
+    new_recipe.setup()
+    new_recipe.execute(dry_run=False)

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -11,7 +11,7 @@ To install the ligandparam package from GitHub, we use miniforge (a minimal vers
 the pre-built conda pacakge described in `env.yaml`. 
 
 For this, to install miniforge you need to follow the instructions in the `miniforge` github page, but minimally this involves
-downloading the installer script and running it. Miniforge is located here: `https://github.com/conda-forge/miniforge?tab=readme-ov-file`_.
+downloading the installer script and running it. Miniforge is located here: `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file>`_.
 
 A simple install for miniforge is as follows:
 

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -7,16 +7,33 @@ This will be updated in the future to allow for installation via pip/anaconda.
 Git Instructions
 ----------------
 
-Packaging for the parametrization script will be improved at a later date, but in the short term,
-you can install the package by cloning the repository and installing it using pip into a conda environment with Python 3.10.
+To install the ligandparam package from GitHub, we use miniforge (a minimal version of conda) to create a new environment and install the package using
+the pre-built conda pacakge described in `env.yaml`. 
+
+For this, to install miniforge you need to follow the instructions in the `miniforge` github page, but minimally this involves
+downloading the installer script and running it. Miniforge is located here: `https://github.com/conda-forge/miniforge?tab=readme-ov-file`_.
+
+A simple install for miniforge is as follows:
+
+.. code-block:: bash
+    wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+    bash Miniforge3-Linux-x86_64.sh
+
+Once miniforge is installed, you can create a new environment and install the ligandparam package using the following commands:
 
 .. code-block:: bash
 
+    source ~/.bashrc # to update environment if you just installed miniforge.
     git clone https://github.com/piskuliche/ligandparam.git
     cd ligandparam
-    conda create -n ligandparam_env python=3.10
-    conda activate ligandparam_env
-    conda install -c conda-forge parmed
-    pip install .
+    mamba env create -f env.yaml
+    conda activate ligandparam
+    pip install -e .
 
-.. note:: Right now the package is only compatible with Python 3.10. Parmed is required for the package to work; however, their versioning is invalid for newer versions of Python.
+
+This will install the ligandparam package in the current environment, making it available for use in python scripts.
+
+As of now, this package also requires antechamber, tleap, and g16 to be accessible within your PATH environment. 
+
+
+    

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -7,22 +7,15 @@ This will be updated in the future to allow for installation via pip/anaconda.
 Git Instructions
 ----------------
 
-To install via git, clone the repository and install the package.
+Packaging for the parametrization script will be improved at a later date, but in the short term,
+you can install the package by cloning the repository and installing it using pip into a conda environment with Python 3.10.
 
 .. code-block:: bash
 
-    git clone path/to/ligandparam
-    cd LigandParamtrize/ligandparam
+    git clone https://github.com/piskuliche/ligandparam.git
+    cd ligandparam
+    conda -create -n ligandparam python=3.10
+    conda install -c conda-forge parmed
     pip install .
 
-Note - it is recommended to be using a conda environment with Python 3.10 (for now) to install and run the package.
-
-To create a conda environment, you can use the following command:
-
-.. code-block:: bash
-
-    conda create -n ligandparam python=3.10
-    conda activate ligandparam
-
-Then you can install the package as described above. Currently, due to dependencies of the Parmed package, the present package is incompatible
-with python versions that use numpy 2.0 or above. 
+.. note:: Right now the package is only compatible with Python 3.10. Parmed is required for the package to work; however, their versioning is invalid for newer versions of Python.

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -16,7 +16,7 @@ downloading the installer script and running it. Miniforge is located here: `Min
 A simple install for miniforge is as follows:
 
 .. code-block:: bash
-    
+
     wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
     bash Miniforge3-Linux-x86_64.sh
 
@@ -29,7 +29,7 @@ Once miniforge is installed, you can create a new environment and install the li
     cd ligandparam
     mamba env create -f env.yaml
     conda activate ligandparam
-    pip install -e .
+    pip install .
 
 
 This will install the ligandparam package in the current environment, making it available for use in python scripts.

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -14,7 +14,8 @@ you can install the package by cloning the repository and installing it using pi
 
     git clone https://github.com/piskuliche/ligandparam.git
     cd ligandparam
-    conda -create -n ligandparam python=3.10
+    conda create -n ligandparam_env python=3.10
+    conda activate ligandparam_env
     conda install -c conda-forge parmed
     pip install .
 

--- a/docs/source/documentation_pages/installation.rst
+++ b/docs/source/documentation_pages/installation.rst
@@ -16,6 +16,7 @@ downloading the installer script and running it. Miniforge is located here: `Min
 A simple install for miniforge is as follows:
 
 .. code-block:: bash
+    
     wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
     bash Miniforge3-Linux-x86_64.sh
 

--- a/docs/source/documentation_pages/multiresp/parmhelper.rst
+++ b/docs/source/documentation_pages/multiresp/parmhelper.rst
@@ -1,7 +1,7 @@
-ligand_param.multiresp.parmhelper
+ligandparam.multiresp.parmhelper
 ---------------------------------
 
-.. automodule:: ligand_param.multiresp.parmhelper
+.. automodule:: ligandparam.multiresp.parmhelper
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/documentation_pages/multiresp/residueresp.rst
+++ b/docs/source/documentation_pages/multiresp/residueresp.rst
@@ -1,7 +1,7 @@
-ligand_param.multiresp.residueresp
+ligandparam.multiresp.residueresp
 ----------------------------------
 
-.. automodule:: ligand_param.multiresp.residueresp
+.. automodule:: ligandparam.multiresp.residueresp
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/documentation_pages/stages.rst
+++ b/docs/source/documentation_pages/stages.rst
@@ -19,6 +19,7 @@ New stages can easily be added by subclassing the :doc:`./stages/abstractstage` 
    ./stages/parmchk.rst
    ./stages/leap.rst
    ./stages/build_system.rst
+   ./stages/typematching.rst
 
 
 .. toctree::

--- a/docs/source/documentation_pages/stages/gaussian.rst
+++ b/docs/source/documentation_pages/stages/gaussian.rst
@@ -1,7 +1,7 @@
-ligand_param.stages.gaussian
+ligandparam.stages.gaussian
 ==================================
 
-.. automodule:: ligand_param.stages.gaussian
+.. automodule:: ligandparam.stages.gaussian
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/documentation_pages/stages/typematching.rst
+++ b/docs/source/documentation_pages/stages/typematching.rst
@@ -1,0 +1,7 @@
+ligandparam.stages.typematching
+==================================
+
+.. automodule:: ligandparam.stages.typematching
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to ligand_param's documentation!
+Welcome to ligandparam's documentation!
 ========================================
 
 
@@ -72,7 +72,7 @@ A key aspect of the code is that you can easily add your own stages to the pipel
    # Remove the Normalize stage
    parametrize_ligand.remove_stage("Normalize1")
 
-   from ligand_param.stages import StageNormalizeCharge
+   from ligandparam.stages import StageNormalizeCharge
 
    # Add a new Normalize stage
    parametrize_ligand.add_stage(StageNormalizeCharge("Normalize2", orig_mol2=test.base_name+".resp.mol2",

--- a/env.yaml
+++ b/env.yaml
@@ -1,0 +1,12 @@
+name: ligandparam
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::python>=3.10
+  - conda-forge::numpy<2
+  - conda-forge::parmed==4.0.0
+  - conda-forge::mdanalysis
+  - conda-forge::rdkit
+  - conda-forge::pandas
+  - pip 
+  

--- a/ligandparam/io/coordinates.py
+++ b/ligandparam/io/coordinates.py
@@ -49,8 +49,26 @@ class Coordinates:
         elements : list
             The elements of the atoms in the structure
         """
+        try:
+            return [atom.element for atom in self.u.atoms]
+        except:
+            return self._get_elements_from_topology()
+    
+    def _get_elements_from_topology(self):
+        """ Grabs the elements from the topology
+        
+        Parameters
+        ----------
+        None
 
-        return [atom.element for atom in self.u.atoms]
+        Returns
+        -------
+        elements : list
+            The elements of the atoms in the structure
+        """
+        from MDAnalysis.topology.guessers import guess_types
+        elements = guess_types(self.u.atoms.names)
+        return elements
     
     def update_coordinates(self, coords, original=False):
         """ Updates the coordinates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ligandparam"
+version = "0.2.0"
+description = "A ligand parameterization package for Amber"
+readme = "README.md"
+requires-python = ">=3.6"
+license = {text = "MIT"}
+authors = [
+  {name = "Zeke Piskulich", email = "piskulichz@gmail.com"}
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent"
+]
+dependencies = [
+  "numpy<2",
+  "pandas",
+  "requests",
+  "MDAnalysis",
+  "pathlib",
+  "parmed",
+  "rdkit"
+]
+urls = { "Homepage" = "https://github.com/piskulichz/ligandparam" }
+
+[tool.setuptools]
+packages = [
+      "ligandparam",
+      "ligandparam.io", 
+      "ligandparam.multiresp",
+      "ligandparam.recipes", 
+      "ligandparam.stages"
+  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,6 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "numpy<2",
-  "pandas",
-  "requests",
-  "MDAnalysis",
-  "pathlib",
-  "parmed",
-  "rdkit"
 ]
 urls = { "Homepage" = "https://github.com/piskulichz/ligandparam" }
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name='ligandparam',
-    version='0.2.0',
-    author='Zeke Piskulich',
-    author_email='piskulichz@gmail.com',
-    description='A ligand parmameterization package for Amber',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/yourusername/my-python-package',
-    packages=find_packages(),
-    install_requires=open('requirements.txt').read().splitlines(),
-    classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-    ],
-    python_requires='>=3.6',
-)
+setup()


### PR DESCRIPTION
This pull request introduces modern packaging practices by replacing the `setup.py` configuration with a `pyproject.toml` file, enhancing dependency management and package data inclusion. Additionally, it refines the `.gitignore` to streamline example file exclusions and updates the documentation to reflect changes in installation instructions, particularly for using Miniforge. Error handling has been added for atom element retrieval, and various typos and formatting issues in the documentation have been corrected. Overall, these changes improve the usability and maintainability of the package.